### PR TITLE
Add shuffleboard controller

### DIFF
--- a/2019RobotCode/src/main/java/frc/robot/Robot.java
+++ b/2019RobotCode/src/main/java/frc/robot/Robot.java
@@ -18,6 +18,7 @@ import frc.robot.Subsystems.DriveSub;
 import frc.robot.Subsystems.ArmSub;
 import frc.robot.Subsystems.HatchSub;
 import frc.robot.Subsystems.VisionSub;
+import frc.robot.shuffleboard.ShuffleboardController;
 
 /**
  * The VM is configured to automatically run this class, and to call the
@@ -42,8 +43,11 @@ public class Robot extends TimedRobot {
    public static final VisionSub VISION_SUB = new VisionSub();
    public static final OI OI = new OI();
 
-   public Robot(){
-   }
+  private ShuffleboardController shuffleboardController;
+
+  public Robot(){
+    this.shuffleboardController = new ShuffleboardController();
+  }
 
   @Override
   public void robotInit() {
@@ -59,7 +63,7 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotPeriodic() {
-    // Scheduler.getInstance().run();
+    Scheduler.getInstance().run();
   }
 
   /**
@@ -82,12 +86,22 @@ public class Robot extends TimedRobot {
   public void teleopInit() {
   }
 
+  @Override
+  public void testInit() {
+    shuffleboardController.test();
+  }
+
+  @Override
+  public void disabledInit() {
+    // @todo: Put some code in here to decelerate gracefully
+    // because this will happen between auto and teleop
+  }
+
   /**
    * This function is called periodically during autonomous.
    */
   @Override
   public void autonomousPeriodic() {
-    Scheduler.getInstance().run();
   }
 
   /**
@@ -95,12 +109,14 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void teleopPeriodic() {
-    Scheduler.getInstance().run();
-
+    /*
     SmartDashboard.putNumber("Gyro Yaw", DRIVE_SUB.getYaw());
     SmartDashboard.putNumber("Limelight X Angle", VISION_SUB.getTargetXAngle());
     SmartDashboard.putNumber("Limelight Area", VISION_SUB.getTargetArea());
     SmartDashboard.putNumber("Potentiometer Value", ARM_SUB.getPotentiometerAngle());
+    */
+
+    shuffleboardController.periodic();
   }
 
   /**
@@ -108,5 +124,14 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void testPeriodic() {
+    shuffleboardController.periodic();
+  }
+
+  /**
+   * This function is called periodically while disabled.
+   */
+  @Override
+  public void disabledPeriodic() {
+    // @todo: See what we need to do here.
   }
 }

--- a/2019RobotCode/src/main/java/frc/robot/RobotMap.java
+++ b/2019RobotCode/src/main/java/frc/robot/RobotMap.java
@@ -11,14 +11,14 @@ package frc.robot;
  */
 public class RobotMap {
   // CAN IDs
-  public static final int CAN_ID_PDP               = 0;
   public static final int CAN_ID_RIGHT_DRIVE       = 1;
   public static final int CAN_ID_RIGHT_DRIVE_SLAVE = 2;
   public static final int CAN_ID_LEFT_DRIVE_SLAVE  = 3;
   public static final int CAN_ID_LEFT_DRIVE        = 4;
-  public static final int CAN_ID_PCM               = 5;
   public static final int CAN_ID_PIGEON_IMU        = 6;
   public static final int CAN_ID_CARGO_INTAKE      = 7;
+  public static final int CAN_ID_PDP               = 20;
+  public static final int CAN_ID_PCM               = 25;
 
   // PWM IDs
   public static final int PWM_PORT_RIGHT_ARM = 0;

--- a/2019RobotCode/src/main/java/frc/robot/shuffleboard/ShuffleboardController.java
+++ b/2019RobotCode/src/main/java/frc/robot/shuffleboard/ShuffleboardController.java
@@ -1,0 +1,13 @@
+package frc.robot.shuffleboard;
+
+public class ShuffleboardController {
+  private TestTab testTab = new TestTab();
+
+  public void test() {
+    testTab.show();
+  }
+
+  public void periodic() {
+    testTab.periodic();
+  }
+}

--- a/2019RobotCode/src/main/java/frc/robot/shuffleboard/TestTab.java
+++ b/2019RobotCode/src/main/java/frc/robot/shuffleboard/TestTab.java
@@ -1,0 +1,37 @@
+package frc.robot.shuffleboard;
+
+import com.ctre.phoenix.motorcontrol.SensorCollection;
+
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import frc.robot.Robot;
+
+public class TestTab {
+  private static final String TITLE = "Test Mode";
+
+  private ShuffleboardTab tab;
+  private NetworkTableEntry encoderLeft;
+  private NetworkTableEntry encoderRight;
+
+  public TestTab() {
+    tab = Shuffleboard.getTab(TITLE);
+    tab.add("Drive - Left", Robot.DRIVE_SUB.left);
+    tab.add("Drive - Right", Robot.DRIVE_SUB.right);
+
+    encoderLeft = tab.add("Drive Encoder - Left", 0).getEntry();
+    encoderRight = tab.add("Drive Encoder - Right", 0).getEntry();
+  }
+
+  public void show() {
+    Shuffleboard.selectTab(TITLE);
+  }
+
+  public void periodic() {
+    int leftPosition = Robot.DRIVE_SUB.leftMaster.getSelectedSensorPosition();
+    int rightPosition= Robot.DRIVE_SUB.rightMaster.getSelectedSensorPosition();
+
+    encoderLeft.setNumber(leftPosition);
+    encoderRight.setNumber(rightPosition);
+  }
+}


### PR DESCRIPTION
This adds a shuffleboard controller and a test tab with entries for the
motors which can be controlled directly in test mode and observed in
teleop. And it adds encoder entries that can be viewed in either mode.

To Test:
1. Run on RoboRio with drive controllers set up correctly on CAN with encoders.
2. Run Test mode, drag motor controls for each one, observe lights on controllers.
3. Spin encoders and ensure they change value.
4. Run Teleop and move sticks on controllers and observe changes.
5. Spin encoders and ensure they change value.
