### PR TITLE
Split out proportions to speed/turn

### DIFF
--- a/2019RobotCode/src/main/java/frc/robot/RobotMap.java
+++ b/2019RobotCode/src/main/java/frc/robot/RobotMap.java
@@ -40,7 +40,7 @@ public class RobotMap {
   public static final int PCM_PORT_RELEASE = 6;
   public static final int PCM_PORT_LATCH = 7;
 
-  // Drive
+  // Drive System
   public static final int GYRO_AXIS_YAW = 0;
   public static final int GYRO_AXIS_PITCH = 1;
   public static final int GYRO_AXIS_ROLL = 2;
@@ -48,8 +48,12 @@ public class RobotMap {
   public static final int ENCODER_TICKS_PER_ROTATION = 256;
   public static final double WHEEL_CIRCUMFERENCE_INCHES = 6 * Math.PI;
   public static final double MOTOR_MINIMUM_POWER = 0.05;
-  public static final double DRIVER_PROPORTION = 0.6;
-  public static final double GUNNER_PROPORTION = 0.3;
+
+  // Drive Controls
+  public static final double DRIVER_SPEED_PROPORTION = 0.6;
+  public static final double DRIVER_TURN_PROPORTION = 0.6;
+  public static final double GUNNER_SPEED_PROPORTION = 0.3;
+  public static final double GUNNER_TURN_PROPORTION = 0.3;
   public static final double MAX_TURN_RATE_DEGREES_PER_SECOND = 180;
   public static final double MAX_VELOCITY_INCHES_PER_SECOND = 10;
 

--- a/2019RobotCode/src/main/java/frc/robot/RobotMap.java
+++ b/2019RobotCode/src/main/java/frc/robot/RobotMap.java
@@ -50,10 +50,10 @@ public class RobotMap {
   public static final double MOTOR_MINIMUM_POWER = 0.05;
 
   // Drive Controls
-  public static final double DRIVER_SPEED_PROPORTION = 0.6;
-  public static final double DRIVER_TURN_PROPORTION = 0.6;
-  public static final double GUNNER_SPEED_PROPORTION = 0.3;
-  public static final double GUNNER_TURN_PROPORTION = 0.3;
+  public static final double DRIVER_SPEED_PROPORTION = 0.8;
+  public static final double DRIVER_TURN_PROPORTION = 0.8;
+  public static final double GUNNER_SPEED_PROPORTION = 0.5;
+  public static final double GUNNER_TURN_PROPORTION = 0.5;
   public static final double MAX_TURN_RATE_DEGREES_PER_SECOND = 180;
   public static final double MAX_VELOCITY_INCHES_PER_SECOND = 10;
 

--- a/2019RobotCode/src/main/java/frc/robot/overlays/DriverFailSafe.java
+++ b/2019RobotCode/src/main/java/frc/robot/overlays/DriverFailSafe.java
@@ -9,8 +9,8 @@ import frc.robot.RobotMap;
  * that relies on no sensors to function.
  */
 public class DriverFailSafe extends ControlOverlay implements ProportionalDrive {
-  public static final double TURN_FACTOR = RobotMap.DRIVER_PROPORTION;
-  public static final double SPEED_FACTOR = RobotMap.DRIVER_PROPORTION;
+  public static final double TURN_FACTOR = RobotMap.DRIVER_TURN_PROPORTION;
+  public static final double SPEED_FACTOR = RobotMap.DRIVER_SPEED_PROPORTION;
 
   public DriverFailSafe(XboxController controller) {
     super(controller);

--- a/2019RobotCode/src/main/java/frc/robot/overlays/GunnerCreepDrive.java
+++ b/2019RobotCode/src/main/java/frc/robot/overlays/GunnerCreepDrive.java
@@ -5,8 +5,8 @@ import edu.wpi.first.wpilibj.GenericHID.Hand;
 import frc.robot.RobotMap;
 
 public class GunnerCreepDrive extends ControlOverlay implements VelocityDrive {
-  public static final double TURN_FACTOR = RobotMap.GUNNER_PROPORTION;
-  public static final double SPEED_FACTOR = RobotMap.GUNNER_PROPORTION;
+  public static final double TURN_FACTOR = RobotMap.GUNNER_TURN_PROPORTION;
+  public static final double SPEED_FACTOR = RobotMap.GUNNER_SPEED_PROPORTION;
 
   public GunnerCreepDrive(XboxController controller) {
     super(controller);

--- a/2019RobotCode/src/main/java/frc/robot/overlays/GunnerFailSafe.java
+++ b/2019RobotCode/src/main/java/frc/robot/overlays/GunnerFailSafe.java
@@ -17,8 +17,8 @@ import frc.robot.Other.XboxRaw;
  * that relies on no sensors to function.
  */
 public class GunnerFailSafe extends GunnerCreepDrive implements ProportionalDrive, HatchControl {
-  public static final double TURN_FACTOR = RobotMap.GUNNER_PROPORTION;
-  public static final double SPEED_FACTOR = RobotMap.GUNNER_PROPORTION;
+  public static final double TURN_FACTOR = RobotMap.GUNNER_TURN_PROPORTION;
+  public static final double SPEED_FACTOR = RobotMap.GUNNER_SPEED_PROPORTION;
 
   private IntakeInCommand intakeInCommand;
   private IntakeOutCommand intakeOutCommand;


### PR DESCRIPTION
This splits out the failsafe proportional drives to speed and turn so
they can be separate values.

Operation of robot should be the same for now.