### PR TITLE
Update hatch/cargo limit switches

### DIFF
--- a/2019RobotCode/src/main/java/frc/robot/RobotMap.java
+++ b/2019RobotCode/src/main/java/frc/robot/RobotMap.java
@@ -29,8 +29,8 @@ public class RobotMap {
   public static final int ANALOG_PORT_ARM_POTENTIOMETER = 0;
 
   // DIO IDs
-  public static final int DIO_PORT_CARGO_LIMIT_LEFT   = 0;
-  public static final int DIO_PORT_CARGO_LIMIT_RIGHT  = 1;
+  public static final int DIO_PORT_CARGO_LIMIT_LEFT   = 8;
+  public static final int DIO_PORT_CARGO_LIMIT_RIGHT  = 9;
   public static final int DIO_PORT_HATCH_LEFT         = 2;
   public static final int DIO_PORT_HATCH_RIGHT        = 3;
 

--- a/2019RobotCode/src/main/java/frc/robot/Subsystems/HatchSub.java
+++ b/2019RobotCode/src/main/java/frc/robot/Subsystems/HatchSub.java
@@ -29,6 +29,14 @@ public class HatchSub extends Subsystem {
     rightLimitSwitch = new DigitalInput(RobotMap.DIO_PORT_HATCH_RIGHT);
   }
 
+  public boolean getLeftLimit() {
+    return leftGantry.getSensorCollection().isFwdLimitSwitchClosed();
+  }
+
+  public boolean getRightLimit() {
+    return rightGantry.getSensorCollection().isFwdLimitSwitchClosed();
+  }
+
   @Override
   public void initDefaultCommand() {
     setDefaultCommand(new HatchStopCommand());

--- a/2019RobotCode/src/main/java/frc/robot/shuffleboard/TestTab.java
+++ b/2019RobotCode/src/main/java/frc/robot/shuffleboard/TestTab.java
@@ -65,8 +65,8 @@ public class TestTab {
     cargoLimitLeft.setBoolean(Robot.CARGO_SUB.limitLeft.get());
     cargoLimitRight.setBoolean(Robot.CARGO_SUB.limitRight.get());
 
-    hatchLimitLeft.setBoolean(Robot.HATCH_SUB.leftLimitSwitch.get());
-    hatchLimitRight.setBoolean(Robot.HATCH_SUB.rightLimitSwitch.get());
+    hatchLimitLeft.setBoolean(Robot.HATCH_SUB.getLeftLimit());
+    hatchLimitRight.setBoolean(Robot.HATCH_SUB.getRightLimit());
 
   }
 }


### PR DESCRIPTION
This updates the cargo switches to be the DIOs used on the main robot,
and updates the hatch limit switches to read from the talon forward
switches.