### PR TITLE
Add trim to proportional/failsafe drive

### DIFF
--- a/2019RobotCode/src/main/java/frc/robot/Commands/ProportionalDriveCommand.java
+++ b/2019RobotCode/src/main/java/frc/robot/Commands/ProportionalDriveCommand.java
@@ -9,11 +9,11 @@ package frc.robot.Commands;
 
 import edu.wpi.first.wpilibj.command.Command;
 import frc.robot.Robot;
+import frc.robot.Other.Utility;
+import frc.robot.shuffleboard.SettingsTab;
 
 public class ProportionalDriveCommand extends Command {
   public ProportionalDriveCommand() {
-    // Use requires() here to declare subsystem dependencies
-    // eg. requires(chassis);
     requires(Robot.DRIVE_SUB);
   }
 
@@ -25,7 +25,30 @@ public class ProportionalDriveCommand extends Command {
   // Called repeatedly when this Command is scheduled to run
   @Override
   protected void execute() {
-    Robot.DRIVE_SUB.drive.arcadeDrive(Robot.OI.getProportionalSpeed(), Robot.OI.getProportionalTurn());
+    double speed = Robot.OI.getProportionalSpeed();
+    double turn = Robot.OI.getProportionalTurn();
+
+    double leftSpeed = (speed + turn);
+    double rightSpeed = (speed - turn);
+
+    leftSpeed = Utility.clamp(leftSpeed, -1.0, 1.0);
+    rightSpeed = Utility.clamp(rightSpeed, -1.0, 1.0);
+
+    double trim = 0.0;
+
+    if (speed > 0) {
+      trim = SettingsTab.getFailsafeTrimForward();
+    } else if (speed < 0) {
+      trim = SettingsTab.getFailsafeTrimReverse();
+    }
+
+    if (trim > 0) {
+      rightSpeed *= (1 - trim);
+    } else if (trim < 0) {
+      leftSpeed *= (1 + trim);
+    }
+
+    Robot.DRIVE_SUB.drive.tankDrive(leftSpeed, rightSpeed);
   }
 
   // Make this return true when this Command no longer needs to run execute()

--- a/2019RobotCode/src/main/java/frc/robot/RobotMap.java
+++ b/2019RobotCode/src/main/java/frc/robot/RobotMap.java
@@ -56,6 +56,8 @@ public class RobotMap {
   public static final double GUNNER_TURN_PROPORTION = 0.5;
   public static final double MAX_TURN_RATE_DEGREES_PER_SECOND = 180;
   public static final double MAX_VELOCITY_INCHES_PER_SECOND = 10;
+  public static final double FAILSAFE_TRIM_FORWARD_DEFAULT = 0.0;
+  public static final double FAILSAFE_TRIM_REVERSE_DEFAULT = 0.0;
 
   //Drive PID Values
   public static final double PID_P_LEFT_DRIVE = 0.0;

--- a/2019RobotCode/src/main/java/frc/robot/shuffleboard/SettingsTab.java
+++ b/2019RobotCode/src/main/java/frc/robot/shuffleboard/SettingsTab.java
@@ -1,0 +1,43 @@
+package frc.robot.shuffleboard;
+
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import frc.robot.RobotMap;
+
+public class SettingsTab {
+  private static final String TITLE = "Settings";
+
+  private static SettingsTab instance;
+
+  private ShuffleboardTab tab;
+  private NetworkTableEntry failsafeTrimForward;
+  private NetworkTableEntry failsafeTrimReverse;
+
+  public static double getFailsafeTrimForward() {
+    return instance.failsafeTrimForward.getDouble(RobotMap.FAILSAFE_TRIM_FORWARD_DEFAULT);
+  }
+
+  public static double getFailsafeTrimReverse() {
+    return instance.failsafeTrimReverse.getDouble(RobotMap.FAILSAFE_TRIM_REVERSE_DEFAULT);
+  }
+
+  public SettingsTab() {
+    instance = this;
+    tab = Shuffleboard.getTab(TITLE);
+
+    failsafeTrimForward = tab.addPersistent(
+      "Failsafe Trim Forward",
+      RobotMap.FAILSAFE_TRIM_FORWARD_DEFAULT
+    ).getEntry();
+
+    failsafeTrimReverse = tab.addPersistent(
+      "Failsafe Trim Reverse",
+      RobotMap.FAILSAFE_TRIM_REVERSE_DEFAULT
+    ).getEntry();
+  }
+
+  public void show() {
+    Shuffleboard.selectTab(TITLE);
+  }
+}

--- a/2019RobotCode/src/main/java/frc/robot/shuffleboard/ShuffleboardController.java
+++ b/2019RobotCode/src/main/java/frc/robot/shuffleboard/ShuffleboardController.java
@@ -1,10 +1,15 @@
 package frc.robot.shuffleboard;
 
 public class ShuffleboardController {
+  private SettingsTab settingsTab = new SettingsTab();
   private TestTab testTab = new TestTab();
 
   public void test() {
     testTab.show();
+  }
+
+  public void settings() {
+    settingsTab.show();
   }
 
   public void periodic() {

--- a/2019RobotCode/src/main/java/frc/robot/shuffleboard/TestTab.java
+++ b/2019RobotCode/src/main/java/frc/robot/shuffleboard/TestTab.java
@@ -1,7 +1,5 @@
 package frc.robot.shuffleboard;
 
-import com.ctre.phoenix.motorcontrol.SensorCollection;
-
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;


### PR DESCRIPTION
This adds a trim value on the settings tab of the shuffleboard for forward and reverse proportional drive.