### PR TITLE
Add support for cargo limit switches

### DIFF
--- a/2019RobotCode/src/main/java/frc/robot/Commands/CargoRollerIntakeCommand.java
+++ b/2019RobotCode/src/main/java/frc/robot/Commands/CargoRollerIntakeCommand.java
@@ -1,0 +1,50 @@
+package frc.robot.Commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+import frc.robot.overlays.CargoControl;
+
+public class CargoRollerIntakeCommand extends Command {
+  private CargoControl controller;
+
+  public CargoRollerIntakeCommand(CargoControl controller) {
+    requires(Robot.CARGO_SUB);
+    this.controller = controller;
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+    double speed = controller.getCargoRollerSpeed();
+
+    if (Robot.CARGO_SUB.isLimit()) {
+      speed = 0;
+    }
+
+    Robot.CARGO_SUB.cargoRollerDirect(speed);
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return Robot.CARGO_SUB.isLimit();
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+    Robot.CARGO_SUB.cargoRollerStop();
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+    end();
+  }
+}

--- a/2019RobotCode/src/main/java/frc/robot/Commands/CargoRollerScoreCommand.java
+++ b/2019RobotCode/src/main/java/frc/robot/Commands/CargoRollerScoreCommand.java
@@ -1,0 +1,50 @@
+package frc.robot.Commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+import frc.robot.overlays.CargoControl;
+
+public class CargoRollerScoreCommand extends Command {
+  private CargoControl controller;
+
+  public CargoRollerScoreCommand(CargoControl controller) {
+    requires(Robot.CARGO_SUB);
+    this.controller = controller;
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+    double speed = controller.getCargoRollerSpeed();
+
+    if (Robot.CARGO_SUB.isLimit() && speed < 0) {
+      speed = 0;
+    }
+
+    Robot.CARGO_SUB.cargoRollerDirect(speed);
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return false;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+    Robot.CARGO_SUB.cargoRollerStop();
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+    end();
+  }
+}

--- a/2019RobotCode/src/main/java/frc/robot/Subsystems/CargoSub.java
+++ b/2019RobotCode/src/main/java/frc/robot/Subsystems/CargoSub.java
@@ -28,6 +28,20 @@ public class CargoSub extends Subsystem {
     roller.setNeutralMode(NeutralMode.Brake);
   }
 
+  public boolean isLimit() {
+    return isLimitLeft() || isLimitRight();
+  }
+
+  public boolean isLimitLeft() {
+    // TODO: Test this on the robot.
+    return ! limitLeft.get();
+  }
+
+  public boolean isLimitRight() {
+    // TODO: Test this on the robot.
+    return ! limitRight.get();
+  }
+
   @Override
   public void initDefaultCommand() {
     setDefaultCommand(new CargoRollerStopCommand());

--- a/2019RobotCode/src/main/java/frc/robot/overlays/GunnerCargoFromFloor.java
+++ b/2019RobotCode/src/main/java/frc/robot/overlays/GunnerCargoFromFloor.java
@@ -3,16 +3,16 @@ package frc.robot.overlays;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.GenericHID.Hand;
 import frc.robot.RobotMap;
-import frc.robot.Commands.CargoRollerDirectCommand;
+import frc.robot.Commands.CargoRollerIntakeCommand;
 
 public class GunnerCargoFromFloor extends GunnerLoading implements CargoControl {
 
-  private CargoRollerDirectCommand cargoControlCommand;
+  private CargoRollerIntakeCommand cargoControlCommand;
 
   public GunnerCargoFromFloor(XboxController controller) {
     super(controller, RobotMap.ARM_CARGO_PICKUP_ANGLE);
 
-    cargoControlCommand = new CargoRollerDirectCommand(this);
+    cargoControlCommand = new CargoRollerIntakeCommand(this);
   }
 
   @Override

--- a/2019RobotCode/src/main/java/frc/robot/overlays/GunnerCargoScoring.java
+++ b/2019RobotCode/src/main/java/frc/robot/overlays/GunnerCargoScoring.java
@@ -3,11 +3,11 @@ package frc.robot.overlays;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.GenericHID.Hand;
 import frc.robot.RobotMap;
-import frc.robot.Commands.CargoRollerDirectCommand;
+import frc.robot.Commands.CargoRollerScoreCommand;
 
 public class GunnerCargoScoring extends GunnerScoring implements CargoControl {
 
-  private CargoRollerDirectCommand cargoControlCommand;
+  private CargoRollerScoreCommand cargoControlCommand;
 
   public GunnerCargoScoring(XboxController controller) {
     super(
@@ -17,7 +17,7 @@ public class GunnerCargoScoring extends GunnerScoring implements CargoControl {
       RobotMap.ARM_CARGO_HIGH_GOAL_ANGLE
     );
 
-    cargoControlCommand = new CargoRollerDirectCommand(this);
+    cargoControlCommand = new CargoRollerScoreCommand(this);
   }
 
   @Override


### PR DESCRIPTION
This adds support for cargo limit switches, but it needs testing on the robot.
The intake stops completely when the switches are tripped.
The scoring stops when the switches are tripped and trying to run reverse.