### PR TITLE
Add cargo limit switch support to failsafe mode

### DIFF
--- a/2019RobotCode/src/main/java/frc/robot/Commands/CargoRollerLimitCommand.java
+++ b/2019RobotCode/src/main/java/frc/robot/Commands/CargoRollerLimitCommand.java
@@ -1,0 +1,67 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.Commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+import frc.robot.overlays.CargoControl;
+
+public class CargoRollerLimitCommand extends Command {
+  private CargoControl controller;
+  private boolean reset;
+
+  public CargoRollerLimitCommand(CargoControl controller) {
+    requires(Robot.CARGO_SUB);
+    this.controller = controller;
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+    this.reset = false;
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+    double speed = controller.getCargoRollerSpeed();
+
+    if (Robot.CARGO_SUB.isLimit()) {
+      if (speed == 0.0) {
+        reset = true;
+      }
+
+      if (!reset) {
+        speed = 0.0;
+      }
+    } else {
+      reset = false;
+    }
+
+    Robot.CARGO_SUB.cargoRollerDirect(speed);
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return false;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+    Robot.CARGO_SUB.cargoRollerStop();
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+    end();
+  }
+}

--- a/2019RobotCode/src/main/java/frc/robot/Subsystems/CargoSub.java
+++ b/2019RobotCode/src/main/java/frc/robot/Subsystems/CargoSub.java
@@ -28,6 +28,18 @@ public class CargoSub extends Subsystem {
     roller.setNeutralMode(NeutralMode.Brake);
   }
 
+  public boolean isLimit() {
+    return isLimitLeft() || isLimitRight();
+  }
+
+  public boolean isLimitLeft() {
+    return limitLeft.get();
+  }
+
+  public boolean isLimitRight() {
+    return limitRight.get();
+  }
+
   @Override
   public void initDefaultCommand() {
     setDefaultCommand(new CargoRollerStopCommand());

--- a/2019RobotCode/src/main/java/frc/robot/overlays/GunnerFailSafe.java
+++ b/2019RobotCode/src/main/java/frc/robot/overlays/GunnerFailSafe.java
@@ -6,6 +6,7 @@ import edu.wpi.first.wpilibj.buttons.JoystickButton;
 import frc.robot.RobotMap;
 import frc.robot.Commands.HatchDirectOpenCloseCommand;
 import frc.robot.Commands.CargoRollerDirectCommand;
+import frc.robot.Commands.CargoRollerLimitCommand;
 import frc.robot.Commands.CargoRollerStopCommand;
 import frc.robot.Commands.HatchDirectMoveCommand;
 import frc.robot.Commands.HatchStopCommand;
@@ -25,7 +26,7 @@ public class GunnerFailSafe
   public static final double TURN_FACTOR = RobotMap.GUNNER_TURN_PROPORTION;
   public static final double SPEED_FACTOR = RobotMap.GUNNER_SPEED_PROPORTION;
 
-  private CargoRollerDirectCommand cargoRollerCommand;
+  private CargoRollerLimitCommand cargoRollerCommand;
   private CargoRollerStopCommand cargoRollerStopCommand;
   private JoystickButton cargoRollerButton;
 
@@ -43,7 +44,7 @@ public class GunnerFailSafe
   public GunnerFailSafe(XboxController controller) {
     super(controller);
 
-    cargoRollerCommand = new CargoRollerDirectCommand(this);
+    cargoRollerCommand = new CargoRollerLimitCommand(this);
     cargoRollerStopCommand = new CargoRollerStopCommand();
     armUpCommand = new MoveArmDirectCommand(ArmSub.Direction.UP);
     armDownCommand = new MoveArmDirectCommand(ArmSub.Direction.DOWN);


### PR DESCRIPTION
This adds cargo limit switch support to the failsafe mode for now.
We will need a way to disable this from the mode at some point.