### PR TITLE
Add first full-auto mode

### DIFF
--- a/2019RobotCode/src/main/java/frc/robot/Commands/AutoHatchScoreLowCommand.java
+++ b/2019RobotCode/src/main/java/frc/robot/Commands/AutoHatchScoreLowCommand.java
@@ -7,15 +7,22 @@ import frc.robot.Subsystems.VisionSub.TargetType;
 
 public class AutoHatchScoreLowCommand extends CommandGroup {
   public AutoHatchScoreLowCommand() {
+    // Let the driver set the approach speed.
+    this(0);
+
+    // Hold the stop until this command is cancelled
+    addSequential(new DriveStopCommand());
+  }
+
+  public AutoHatchScoreLowCommand(int approachSpeed) {
     setName("HATCH LOW");
 
     addSequential(new AutoArmCommand(ArmPreset.Low, -70));
-    addSequential(new AutoSquareUpCommand(TargetType.HATCH, RobotMap.VISION_DISTANCE_TO_HATCH_LOW));
+    addSequential(new AutoSquareUpCommand(TargetType.HATCH, RobotMap.VISION_DISTANCE_TO_HATCH_LOW, approachSpeed));
 
     // Push forward and drop.
     addSequential(new AutoVelocityMoveCommand(300, 0, 1.00));
     addSequential(new AutoArmCommand(ArmPreset.Low, +400, true));
     addSequential(new AutoVelocityMoveCommand(-450, 0, 0.75));
-    addSequential(new DriveStopCommand());
   }
 }

--- a/2019RobotCode/src/main/java/frc/robot/Commands/AutoLaunchCommand.java
+++ b/2019RobotCode/src/main/java/frc/robot/Commands/AutoLaunchCommand.java
@@ -11,13 +11,6 @@ public class AutoLaunchCommand extends CommandGroup {
     addSequential(new AutoArmCommand(ArmPreset.Low, 0));
     addSequential(new AutoVelocityMoveCommand((int)(RobotMap.MAX_ENCODER_VELOCITY * 0.80), 0, 1.25));
     addSequential(new AutoVelocityMoveCommand((int)(RobotMap.MAX_ENCODER_VELOCITY * 0.25), 0, 0.50));
-    addSequential(new AutoVelocityMoveCommand((int)(RobotMap.MAX_ENCODER_VELOCITY * 0.25), 0, 0.25));
     addSequential(new AutoVelocityMoveCommand(0, 0, 0));
-  }
-
-  @Override
-  protected boolean isFinished() {
-    boolean finished = super.isFinished();
-    return finished;
   }
 }

--- a/2019RobotCode/src/main/java/frc/robot/Commands/AutoLaunchHatchCargoShipLeftCommand.java
+++ b/2019RobotCode/src/main/java/frc/robot/Commands/AutoLaunchHatchCargoShipLeftCommand.java
@@ -1,0 +1,79 @@
+package frc.robot.Commands;
+
+import frc.robot.RobotMap;
+import frc.robot.RobotMap.ArmPreset;
+import frc.robot.Subsystems.VisionSub.PipelineIndex;
+
+public class AutoLaunchHatchCargoShipLeftCommand extends FullAutoCommandGroup {
+  public AutoLaunchHatchCargoShipLeftCommand(AutoModes.StartPosition position) {
+    setName("CSHIP_LEFT");
+
+    // Sometimes the auto arm command doesn't quite work the first time. :/
+    addSequential(new AutoArmCommand(ArmPreset.Low, 0, true));
+    addSequential(new AutoArmCommand(ArmPreset.Low, 0, true));
+    addSequential(new VisionSetPipelineCommand(PipelineIndex.VISION_TARGET_LEFT));
+
+    switch (position) {
+      case HAB_1_CENTER:
+        moveFromHab1Center();
+        break;
+      case HAB_1_LEFT:
+        moveFromHab1Left();
+        break;
+      case HAB_1_RIGHT:
+        moveFromHab1Right();
+        break;
+    }
+
+    // Auto scoring
+    addSequential(new AutoHatchScoreLowCommand((int)(RobotMap.MAX_ENCODER_VELOCITY * 0.25)));
+
+    // Stop
+    addSequential(new AutoVelocityMoveCommand(0, 0, 0));
+    addSequential(new VisionSetPipelineCommand(PipelineIndex.HUMAN_VIEW));
+  }
+
+  private void moveFromHab1Left() {
+    // Initial launch
+    addSequential(new AutoVelocityMoveCommand(
+      (int)(RobotMap.MAX_ENCODER_VELOCITY * 0.30),
+      0,
+      0.20
+    ));
+    addSequential(new AutoVelocityMoveCommand(
+      (int)(RobotMap.MAX_ENCODER_VELOCITY * 0.60),
+      0,
+      0.20
+    ));
+    addSequential(new AutoVelocityMoveCommand(
+      (int)(RobotMap.MAX_ENCODER_VELOCITY * 0.90),
+      0,
+      0.50
+    ));
+
+    // Arc right
+    addSequential(new AutoVelocityMoveCommand(
+      (int)(RobotMap.MAX_ENCODER_VELOCITY * 0.50),
+      (int)(RobotMap.MAX_ENCODER_VELOCITY * 0.45),
+      0.6
+    ));
+    // Arc left
+    addSequential(new AutoVelocityMoveCommand(
+      (int)(RobotMap.MAX_ENCODER_VELOCITY * 0.50),
+      (int)(RobotMap.MAX_ENCODER_VELOCITY * -0.45),
+      0.6
+    ));
+  }
+
+  private void moveFromHab1Center() {
+  }
+
+  private void moveFromHab1Right() {
+  }
+
+  @Override
+  protected boolean isFinished() {
+    boolean finished = super.isFinished();
+    return finished;
+  }
+}

--- a/2019RobotCode/src/main/java/frc/robot/Commands/AutoModes.java
+++ b/2019RobotCode/src/main/java/frc/robot/Commands/AutoModes.java
@@ -1,0 +1,62 @@
+package frc.robot.Commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+
+public class AutoModes {
+  public enum StartPosition {
+    HAB_1_CENTER,
+    HAB_1_LEFT,
+    HAB_1_RIGHT,
+  }
+
+  public enum StartTask {
+    NOTHING,
+    LAUNCH,
+    CARGO_SHIP_LEFT,
+    CARGO_SHIP_RIGHT,
+    LEFT_ROCKET_LOW,
+    RIGHT_ROCKET_LOW,
+  }
+
+  public SendableChooser<StartPosition> positionChooser;
+  public SendableChooser<StartTask> taskChooser;
+
+  public AutoModes() {
+    this.positionChooser = new SendableChooser<StartPosition>();
+    this.taskChooser = new SendableChooser<StartTask>();
+
+    positionChooser.setName("Position");
+    positionChooser.setDefaultOption("Center", StartPosition.HAB_1_CENTER);
+    positionChooser.addOption("Left", StartPosition.HAB_1_LEFT);
+    positionChooser.addOption("Right", StartPosition.HAB_1_RIGHT);
+
+    taskChooser.setName("Task");
+    taskChooser.setDefaultOption("Nothing", StartTask.NOTHING);
+    taskChooser.addOption("Launch", StartTask.LAUNCH);
+    taskChooser.addOption("CShip Left", StartTask.CARGO_SHIP_LEFT);
+    taskChooser.addOption("CShip Right", StartTask.CARGO_SHIP_RIGHT);
+    taskChooser.addOption("L Rkt Low", StartTask.LEFT_ROCKET_LOW);
+    taskChooser.addOption("R Rkt Low", StartTask.RIGHT_ROCKET_LOW);
+  }
+
+  public Command getAutoCommand() {
+    StartPosition position = positionChooser.getSelected();
+    StartTask task = taskChooser.getSelected();
+
+    switch (task) {
+      case CARGO_SHIP_LEFT:
+        return new AutoLaunchHatchCargoShipLeftCommand(position);
+      case CARGO_SHIP_RIGHT:
+        return new AutoNothingCommand();
+      case LEFT_ROCKET_LOW:
+        return new AutoNothingCommand();
+      case RIGHT_ROCKET_LOW:
+        return new AutoNothingCommand();
+      case LAUNCH:
+        return new AutoLaunchCommand();
+      default:
+        return new AutoNothingCommand();
+    }
+  }
+}

--- a/2019RobotCode/src/main/java/frc/robot/Commands/AutoNothingCommand.java
+++ b/2019RobotCode/src/main/java/frc/robot/Commands/AutoNothingCommand.java
@@ -1,0 +1,12 @@
+package frc.robot.Commands;
+
+import edu.wpi.first.wpilibj.command.CommandGroup;
+import frc.robot.RobotMap.ArmPreset;
+
+public class AutoNothingCommand extends CommandGroup {
+  public AutoNothingCommand() {
+    setName("NOTHING");
+
+    addSequential(new AutoArmCommand(ArmPreset.Low, 0));
+  }
+}

--- a/2019RobotCode/src/main/java/frc/robot/Commands/AutoSquareUpCommand.java
+++ b/2019RobotCode/src/main/java/frc/robot/Commands/AutoSquareUpCommand.java
@@ -37,7 +37,14 @@ public class AutoSquareUpCommand extends Command {
     public void pidWrite(double output) {
       int encoderDifferential = (int) output;
 
-      int speed = Robot.OI.getEncoderSpeed();
+      int speed;
+      int driverSpeed = Robot.OI.getEncoderSpeed();
+
+      if (driverSpeed != 0) {
+        speed = driverSpeed;
+      } else {
+        speed = approachSpeed;
+      }
 
       int leftVelocity = speed - encoderDifferential;
       int rightVelocity = speed + encoderDifferential;
@@ -58,8 +65,14 @@ public class AutoSquareUpCommand extends Command {
   private int targetRotationArrayIndex;
   private double targetDistance;
   private double desiredDistance;
+  private int approachSpeed;
 
   public AutoSquareUpCommand(TargetType targetType, double desiredDistance) {
+    // Let the driver set the approach speed.
+    this(targetType, desiredDistance, 0);
+  }
+
+  public AutoSquareUpCommand(TargetType targetType, double desiredDistance, int approachSpeed) {
     requires(Robot.DRIVE_SUB);
     requires(Robot.VISION_SUB);
     setName("SQUARE UP");
@@ -70,6 +83,7 @@ public class AutoSquareUpCommand extends Command {
     this.targetRotationArray = new double[RobotMap.PID_VISION_TARGET_ROTATION_SAMPLES];
     this.targetRotationArrayIndex = 0;
     this.targetDistance = Double.MAX_VALUE;
+    this.approachSpeed = approachSpeed;
 
     PIDValues yawPIDValues = RobotMap.PID_ADJUST_YAW;
 

--- a/2019RobotCode/src/main/java/frc/robot/Commands/FullAutoCommandGroup.java
+++ b/2019RobotCode/src/main/java/frc/robot/Commands/FullAutoCommandGroup.java
@@ -1,0 +1,12 @@
+package frc.robot.Commands;
+
+import edu.wpi.first.wpilibj.command.CommandGroup;
+import frc.robot.Robot;
+
+public abstract class FullAutoCommandGroup extends CommandGroup {
+
+  @Override
+  protected boolean isFinished() {
+    return Robot.OI.isAnyStickActive() || super.isFinished();
+  }
+}

--- a/2019RobotCode/src/main/java/frc/robot/Commands/VisionSetPipelineCommand.java
+++ b/2019RobotCode/src/main/java/frc/robot/Commands/VisionSetPipelineCommand.java
@@ -1,0 +1,24 @@
+package frc.robot.Commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+import frc.robot.Subsystems.VisionSub.PipelineIndex;
+
+public class VisionSetPipelineCommand extends Command {
+  private PipelineIndex index;
+
+  public VisionSetPipelineCommand(PipelineIndex index) {
+    this.index = index;
+  }
+
+  @Override
+  protected void initialize() {
+    super.initialize();
+    Robot.VISION_SUB.setPipeline(index);
+  }
+
+  @Override
+  protected boolean isFinished() {
+    return true;
+  }
+}

--- a/2019RobotCode/src/main/java/frc/robot/OI.java
+++ b/2019RobotCode/src/main/java/frc/robot/OI.java
@@ -114,6 +114,10 @@ public class OI implements ProportionalDrive, VelocityDrive {
     return speed;
   }
 
+  public boolean isAnyStickActive() {
+    return driverControls.isStickActive() || gunnerControls.isStickActive();
+  }
+
   public boolean isGunnerDriving() {
     return gunnerControls.getEncoderTurnDifferential() != 0 || gunnerControls.getEncoderSpeed() != 0;
   }
@@ -165,7 +169,6 @@ public class OI implements ProportionalDrive, VelocityDrive {
       }
 
       if (speed > max) {
-        System.out.println("limit: " + speed + " to " + max + " (lastEncoderSpeed=" + lastEncoderSpeed + ")");
         speed = max;
       }
     }

--- a/2019RobotCode/src/main/java/frc/robot/Robot.java
+++ b/2019RobotCode/src/main/java/frc/robot/Robot.java
@@ -8,10 +8,11 @@
 package frc.robot;
 
 import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.command.Scheduler;
 import frc.robot.Subsystems.CargoSub;
 import frc.robot.Subsystems.DriveSub;
-import frc.robot.Commands.AutoLaunchCommand;
+import frc.robot.Commands.AutoModes;
 import frc.robot.Subsystems.ArmSub;
 import frc.robot.Subsystems.VisionSub;
 import frc.robot.Subsystems.VisionSub.PipelineIndex;
@@ -30,12 +31,12 @@ public class Robot extends TimedRobot {
   public static final CargoSub CARGO_SUB = new CargoSub();
   public static final VisionSub VISION_SUB = new VisionSub();
   public static final OI OI = new OI();
+  public static final AutoModes autoModes = new AutoModes();
 
   private static Robot robotInstance;
 
   private ShuffleboardController shuffleboardController;
   private boolean failsafeActive;
-  private AutoLaunchCommand autoLaunchCommand = new AutoLaunchCommand();
 
   public Robot() {
     robotInstance = this;
@@ -100,7 +101,11 @@ public class Robot extends TimedRobot {
   public void autonomousInit() {
     shuffleboardController.drive();
     ARM_SUB.compressor.setClosedLoopControl(true);
-    autoLaunchCommand.start();
+
+    Command autoCommand = autoModes.getAutoCommand();
+    if (autoCommand != null) {
+      autoCommand.start();
+    }
   }
 
   @Override

--- a/2019RobotCode/src/main/java/frc/robot/Subsystems/VisionSub.java
+++ b/2019RobotCode/src/main/java/frc/robot/Subsystems/VisionSub.java
@@ -23,7 +23,9 @@ public class VisionSub extends SubsystemBase {
   public enum PipelineIndex {
     UNKNOWN(-1),
     VISION_TARGET(0),
-    HUMAN_VIEW(1);
+    HUMAN_VIEW(1),
+    VISION_TARGET_LEFT(2),
+    VISION_TARGET_RIGHT(3);
 
     public final int index;
 

--- a/2019RobotCode/src/main/java/frc/robot/controls/Controls.java
+++ b/2019RobotCode/src/main/java/frc/robot/controls/Controls.java
@@ -1,11 +1,20 @@
 package frc.robot.controls;
 
 import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.GenericHID.Hand;
+import frc.robot.RobotMap;
+import frc.robot.Other.Utility;
 
 public class Controls {
   protected XboxController controller;
 
   public Controls(XboxController controller) {
     this.controller = controller;
+  }
+
+  public boolean isStickActive() {
+    double speed = Utility.deadband(controller.getY(Hand.kLeft), RobotMap.DRIVE_STICK_DEADBAND);
+    double turn = Utility.deadband(controller.getX(Hand.kRight), RobotMap.DRIVE_STICK_DEADBAND);
+    return (speed != 0 || turn != 0);
   }
 }

--- a/2019RobotCode/src/main/java/frc/robot/shuffleboard/SettingsTab.java
+++ b/2019RobotCode/src/main/java/frc/robot/shuffleboard/SettingsTab.java
@@ -3,6 +3,7 @@ package frc.robot.shuffleboard;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import frc.robot.Robot;
 import frc.robot.RobotMap;
 
 public class SettingsTab {
@@ -35,6 +36,9 @@ public class SettingsTab {
       "Failsafe Trim Reverse",
       RobotMap.FAILSAFE_TRIM_REVERSE_DEFAULT
     ).getEntry();
+
+    tab.add(Robot.autoModes.positionChooser);
+    tab.add(Robot.autoModes.taskChooser);
   }
 
   public void show() {


### PR DESCRIPTION
This adds the first full auto mode to score the a panel on the left
cargo ship hatch. In order to do this, the following changes were made:

1. Add command to switch vision pipelines (using one for targeting left)
2. Adapt AutoSquareUp and Hatch Low to take an approach speed
3. Add code to check if driver of gunner sticks are in use
4. Finish the auto mode early if driver or gunner tries to drive