### PR TITLE
Use bumpers for left/right vision

### DIFF
--- a/2019RobotCode/src/main/java/frc/robot/Commands/AutoModePreviewCommand.java
+++ b/2019RobotCode/src/main/java/frc/robot/Commands/AutoModePreviewCommand.java
@@ -7,7 +7,6 @@ public class AutoModePreviewCommand extends Command {
   private boolean active;
 
   public AutoModePreviewCommand(boolean active) {
-    requires(Robot.VISION_SUB);
     this.active = active;
   }
 

--- a/2019RobotCode/src/main/java/frc/robot/OI.java
+++ b/2019RobotCode/src/main/java/frc/robot/OI.java
@@ -44,6 +44,7 @@ public class OI implements ProportionalDrive, VelocityDrive {
   private int lastEncoderSpeed;
   private boolean driverSlow;
   private boolean autoModePreview;
+  private PipelineIndex visionPipelineIndex;
   private DriverControls driverControls;
   private GunnerControls gunnerControls;
   private FullAutoCancelTrigger fullAutoCancelTrigger;
@@ -67,7 +68,7 @@ public class OI implements ProportionalDrive, VelocityDrive {
     gunnerControls.armCycleDownTrigger.whenActive(new ArmPresetCycleCommand(Direction.DOWN));
     gunnerControls.armCycleUpTrigger.whenActive(new ArmPresetCycleCommand(Direction.UP));
 
-    gunnerControls.autoModeButton.whenPressed(new AutoModePreviewCommand(true));
+    gunnerControls.autoModeButton.whileActive(new AutoModePreviewCommand(true));
     gunnerControls.autoModeButton.whenReleased(new AutoModePreviewCommand(false));
 
     gunnerControls.autoHatchLoadingStationTrigger.whileActive(new AutoHatchLoadingStationCommand());
@@ -93,15 +94,24 @@ public class OI implements ProportionalDrive, VelocityDrive {
   }
 
   public void setAutoModePreview(boolean autoModePreview) {
-    if (this.autoModePreview != autoModePreview) {
-      this.autoModePreview = autoModePreview;
+    PipelineIndex index = PipelineIndex.HUMAN_VIEW;
 
-      if (autoModePreview) {
-        Robot.VISION_SUB.setPipeline(PipelineIndex.VISION_TARGET);
+    if (autoModePreview) {
+      if (gunnerControls.autoTargetLeftButton.get()) {
+        index = PipelineIndex.VISION_TARGET_LEFT;
+      } else if (gunnerControls.autoTargetRightButton.get()) {
+        index = PipelineIndex.VISION_TARGET_RIGHT;
       } else {
-        Robot.VISION_SUB.setPipeline(PipelineIndex.HUMAN_VIEW);
+        index = PipelineIndex.VISION_TARGET;
       }
     }
+
+    if (this.visionPipelineIndex != index) {
+      Robot.VISION_SUB.setPipeline(index);
+      this.visionPipelineIndex = index;
+    }
+
+    this.autoModePreview = autoModePreview;
   }
 
   @Override

--- a/2019RobotCode/src/main/java/frc/robot/controls/GunnerControls.java
+++ b/2019RobotCode/src/main/java/frc/robot/controls/GunnerControls.java
@@ -16,8 +16,8 @@ public class GunnerControls extends Controls
 
   public final JoystickButton cargoRollerButton;
   public final JoystickButton autoModeButton;
-  public final JoystickButton autoHatchModeButton;
-  public final JoystickButton autoCargoModeButton;
+  public final JoystickButton autoTargetLeftButton;
+  public final JoystickButton autoTargetRightButton;
   public final JoystickButton autoScoreLowButton;
   public final JoystickButton autoScoreMidButton;
   public final JoystickButton autoScoreHighButton;
@@ -30,10 +30,6 @@ public class GunnerControls extends Controls
   public final ButtonChordTrigger autoHatchScoreLowTrigger;
   public final ButtonChordTrigger autoHatchScoreMidTrigger;
   public final ButtonChordTrigger autoHatchScoreHighTrigger;
-  public final ButtonChordTrigger autoCargoLoadingStationTrigger;
-  public final ButtonChordTrigger autoCargoScoreLowTrigger;
-  public final ButtonChordTrigger autoCargoScoreMidTrigger;
-  public final ButtonChordTrigger autoCargoScoreHighTrigger;
 
   public GunnerControls(XboxController controller) {
     super(controller);
@@ -42,8 +38,8 @@ public class GunnerControls extends Controls
     armAdjustUpButton = new JoystickButton(controller, XboxRaw.BumperRight.value);
     armAdjustDownButton = new JoystickButton(controller, XboxRaw.BumperLeft.value);
     autoModeButton = new JoystickButton(controller, XboxRaw.Back.value);
-    autoHatchModeButton = new JoystickButton(controller, XboxRaw.BumperLeft.value);
-    autoCargoModeButton = new JoystickButton(controller, XboxRaw.BumperRight.value);
+    autoTargetLeftButton = new JoystickButton(controller, XboxRaw.BumperLeft.value);
+    autoTargetRightButton = new JoystickButton(controller, XboxRaw.BumperRight.value);
     autoScoreLowButton = new JoystickButton(controller, XboxRaw.A.value);
     autoScoreMidButton = new JoystickButton(controller, XboxRaw.X.value);
     autoScoreHighButton = new JoystickButton(controller, XboxRaw.Y.value);
@@ -56,29 +52,16 @@ public class GunnerControls extends Controls
     armCycleDownTrigger = new DPadTrigger(controller, DPadValue.Down);
 
     autoHatchLoadingStationTrigger = new ButtonChordTrigger(
-      new JoystickButton[] {autoModeButton, autoHatchModeButton, autoLoadingStationButton}
+      new JoystickButton[] {autoModeButton, autoLoadingStationButton}
     );
     autoHatchScoreLowTrigger = new ButtonChordTrigger(
-      new JoystickButton[] {autoModeButton, autoHatchModeButton, autoScoreLowButton}
+      new JoystickButton[] {autoModeButton, autoScoreLowButton}
     );
     autoHatchScoreMidTrigger = new ButtonChordTrigger(
-      new JoystickButton[] {autoModeButton, autoHatchModeButton, autoScoreMidButton}
+      new JoystickButton[] {autoModeButton, autoScoreMidButton}
     );
     autoHatchScoreHighTrigger = new ButtonChordTrigger(
-      new JoystickButton[] {autoModeButton, autoHatchModeButton, autoScoreHighButton}
-    );
-
-    autoCargoLoadingStationTrigger = new ButtonChordTrigger(
-      new JoystickButton[] {autoModeButton, autoCargoModeButton, autoLoadingStationButton}
-    );
-    autoCargoScoreLowTrigger = new ButtonChordTrigger(
-      new JoystickButton[] {autoModeButton, autoCargoModeButton, autoScoreLowButton}
-    );
-    autoCargoScoreMidTrigger = new ButtonChordTrigger(
-      new JoystickButton[] {autoModeButton, autoCargoModeButton, autoScoreMidButton}
-    );
-    autoCargoScoreHighTrigger = new ButtonChordTrigger(
-      new JoystickButton[] {autoModeButton, autoCargoModeButton, autoScoreHighButton}
+      new JoystickButton[] {autoModeButton, autoScoreHighButton}
     );
   }
 
@@ -89,8 +72,8 @@ public class GunnerControls extends Controls
       armAdjustUpButton.get() ||
       armAdjustDownButton.get() ||
       autoModeButton.get() ||
-      autoHatchModeButton.get() ||
-      autoCargoModeButton.get() ||
+      autoTargetLeftButton.get() ||
+      autoTargetRightButton.get() ||
       autoScoreLowButton.get() ||
       autoScoreMidButton.get() ||
       autoScoreHighButton.get() ||


### PR DESCRIPTION
This removes the bumper support for hatch cargo, removes cargo triggers
and replaces bumpers with left/right vision pipeline selection